### PR TITLE
fix: add basePath as arg

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,10 @@ function initializeGitHub(env: Env, installationId: number) {
 	});
 }
 
+function ensurePath(basePath: string, subPath: string): string {
+    return basePath ? `${basePath}/${subPath}` : subPath;
+}
+
 export default {
 	async fetch(request: Request, env: Env): Promise<Response> {
 		try {
@@ -84,11 +88,12 @@ export default {
 
 							// 1. Get the test file from the repository
 							const changedFiles = await github.listPullRequestFiles(context);
-							const testFile = changedFiles.find((file) => file.filename === `${basePath}/test/index.spec.ts`);
+							const testFilePath = ensurePath(basePath, 'test/index.spec.ts');
+							const testFile = changedFiles.find((file) => file.filename === testFilePath);
 
 							if (!testFile) {
 								const body =
-									`Please change the test file (${basePath}/test/index.spec.ts) in this pull request. It should contain new requirements for the code you will need me to write.`;
+									`Please change the test file (${testFilePath}) in this pull request. It should contain new requirements for the code you will need me to write.`;
 								await github.postComment(context, body, workingCommentId);
 								return;
 							}
@@ -126,7 +131,8 @@ export default {
 							}
 
 							// 4. Write the generated file (src/index.ts) to the pull request's branch
-							const file = { path: `${basePath}/src/index.ts`, content: completedCode };
+							const srcFilePath = ensurePath(basePath, 'src/index.ts');
+							const file = { path: srcFilePath, content: completedCode };
 							await github
 								.pushFileToPullRequest(context, file, 'feat: generated code 🤖')
 								.then(async () => {


### PR DESCRIPTION
### Issue

WALL-E can't reach the test file when a repo contains multiple workers

#### My fix
This PR resolves https://github.com/1712n/dni-code-generation-research/pull/12#issuecomment-2156036443: WALL-E not being able to find a test file if there's a different repo structure

#### Ev's suggestion

pass the worker directory to wall-e as a parameter in the comment

@jalmonter please take a look at and lmk what you think, thanks!