### PR TITLE
Fix: Add Prompts & Doc logging

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -141,7 +141,9 @@ export default {
 									const elapsedTime = getElapsedSeconds(message.timestamp);
 									const debugInfo = formatDebugInfo({
 										elapsedTime,
-										generateWorkerPrompts: JSON.stringify(generateWorkerPrompts, null, 2),
+										documentationExtractionPrompt: JSON.stringify(documentationPrompts.system, null, 2),
+										relevantDocumentation: JSON.stringify(relevantDocumentation, null, 2),
+										generateWorkerPrompt: JSON.stringify(generateWorkerPrompts.system, null, 2),
 									});
 									const comment = `Code generated successfully! 🎉\n\n${debugInfo}`;
 									await github.postComment(context, comment, workingCommentId);


### PR DESCRIPTION
We'd like to log the prompts we send to LLMs every time we call WALL-E. Right now the logging of prompts is executed only if no code or documentation was generated 

In the ideal scenario, I'd prefer if we track these things separately (feel free to suggest alternatives):
- used prompts
- extracted relevant documentation
- temperature (maybe)