### PR TITLE
feat: add drizzle doc

### DIFF
--- a/src/prompt/markdown/cloudflare_documentation.md
+++ b/src/prompt/markdown/cloudflare_documentation.md
@@ -438,6 +438,45 @@ export default {
   }
 }
 ```
+### Query
+```ts
+// find many
+const users = await db.query.users.findMany();
+// Partial fields select
+const posts = await db.query.posts.findMany({
+  columns: {
+    id: true,
+    content: true,
+  },
+  with: {
+    comments: true,
+  }
+});
+// Exclude and Include fields in the same query:
+const users = await db.query.users.findMany({
+  columns: {
+    name: true,
+    id: false //ignored
+  },
+});
+// find 5 posts
+await db.query.posts.findMany({
+  limit: 5,
+});
+// Find posts and get 3 comments at most:
+await db.query.posts.findMany({
+  with: {
+    comments: {
+      limit: 3,
+    },
+  },
+});
+// order by
+import { desc, asc } from 'drizzle-orm';
+await db.query.posts.findMany({
+  orderBy: [asc(posts.id)],
+});
+```
 ### SQL Insert
 ```ts
 await db.insert(users).values({ name: 'Andrew' });


### PR DESCRIPTION
I compiled a pretty small documentation from Drizzle. I added mostly what I use very often. Please suggest what else to include!

Wasn't sure about [Magical sql operator](https://orm.drizzle.team/docs/sql)

UPD: Oh, I forgot `find`! 