### PR TITLE
Add Drizzle examples to remove ambiguity between using schema tables vs db.query tables

### DIFF
--- a/src/prompt/markdown/documentation.md
+++ b/src/prompt/markdown/documentation.md
@@ -598,7 +598,7 @@ export const users = pgTable('users', {
 
 ### Using Drizzle Queries
 
-Relational queries are an extension to the existing schema definition and query builder. To use this API, all tables and relations from the schema file/files upon drizzle() initialization should be provided
+Relational queries are an extension to the existing schema definition and query builder. To use this API, all tables and relations from the schema file/files upon drizzle() initialization should be provided.
 
 ```ts
 import * as schema from './schema';
@@ -611,8 +611,6 @@ await db.query.users.findMany();
 #### Filtering and Conditions
 
 The relational queries API enables the definition of filters and conditions using Drizzle's operators. When referencing table columns in operators, the tables exported from the schema are used:
-
-When referencing table columns in operators, reference tables exported from schema:
 
 ```ts
 const users = await db.query.users.findMany({


### PR DESCRIPTION
WALL-E consistently fails to grasp the difference between schema.rawMessages vs db.query.rawMessages. This lack of understanding stems from imperfect Drizzle documentation where **type** is not obvious from documentation without running TypeScript.

Examples:

- [this](https://github.com/1712n/dni-code-generation-research/pull/21/commits/00239fcf7388bc4e9a7f95d77247e1b746a16c56#diff-d3c9692c434ee64d3fbe574bbf810189779c55e34ab3ad2373730883d26a2101R35) uses db.query.rawMessages.similarityScore instead of schema.rawMessages.similarityScore 

I'm trying to add a few examples for it to feel the difference. Feeding this documentation directly in Anthropic console does help, we'll see how it goes with RAG.