### PR TITLE
Adjust document extraction prompt

### DIFF
--- a/src/prompt/markdown/documentation_extraction.md
+++ b/src/prompt/markdown/documentation_extraction.md
@@ -1,9 +1,11 @@
-You will be preparing Relevant Documentation for a TypeScript Engineer specializing in Test Driven Development, who will write a Cloudflare Worker based on the provided Test File.
+You are an expert in documentation extraction for software development. Your task is to analyze the given Test File and Documentation, then extract and compile all relevant documentation sections that directly relate to implementing and testing the functionality described in the Test File.
 
-Generate Relevant Documentation by copying the Documentation File and removing all parts that are irrelevant to the functional requirements and Vitest integration tests from the Test File. Assume the TypeScript Engineer is unfamiliar with any of the technologies and concepts in the Documentation File.
+Key requirements:
 
-Critical:
-
-- Exclude irrelevant information, but ensure all potentially helpful content from the Documentation File is retained.
+- Include full, unmodified sections from the Documentation that are relevant to the Test File. Do not rephrase or summarize.
+- Include documentation in original order
 - Don't include anything from outside of the Documentation File.
 - Provide the relevant documentation directly, with no introductory phrases, additional formatting, code backticks, or extraneous content.
+- Ensure all examples, code snippets, and usage details are included for relevant sections.
+- Focus on sections that are directly mentioned or used in the Test File.
+- Exclude sections that are not directly used in the Test File.


### PR DESCRIPTION
Hi! We can see that document extraction oftentimes includes irrelevant information, and omits relevant pieces.

For example, it would include detailed sections on Workers AI and all models for a test while that doesn't call Workers AI at all. And then it would strip Drizzle ORM heavily.

Proposed change is compiled based on Clause suggested prompt plus a few manual edits. It seems to generate better results for me.

<details><summary>Prompt</summary>

	You are an expect in AI prompt generation.

	Your task is to analyze Current test file, Current documentation, and a few Previous prompts below and Results analysis, and generate a new prompt that will result in better documentation extraction.

	# Current test file
	<code>{{test_file}}</code>

	# Current documentation
	<quote>{{documentation}}</quote>


	# Previous prompt
	<quote>{{prompt1}}</quote>

	# Results analysis
	{{annotation1_1}}
	{{annotation1_2}}
	{{annotation1_3}}
</details>

<details>
    <summary>Annotations used are similar to this</summary>

	- Workers AI section is not relevant to test file because it never calls Workers AI directly.
	- AI Gateway section is irrelevant because test file never calls Workers AI directly.
	- Cache API section is too short. Should include all relevant sections with usage examples.
	- Drizzle ORM section is too short. Should include all relevant sections with usage examples.
	- Test APIs section - sentenses should not be rephased, should remain original wording, should contain all examples
	- Workers AI section is not relevant to test file because it never calls Workers AI directly.
	- Drizzle ORM is mentioned in functional requirements and in test, but documentation is too short, lacks batch update examples
	- all documentation extracts are too short, lack concrete usage examples
	- missing relevant Drizzle ORM documentation and examples
	- contains recommendations that are not present in given documentation
</details>