### PR TITLE
changed analyze test file comment structure and wording

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -134,7 +134,7 @@ export default {
 							} else {
 								const { test_file_analysis_result: testFileAnalysisResult } = extractXMLContent(analyzedTestFile);
 								if (testFileAnalysisResult) {
-									const body = `The test file contains conflicts that need to be resolved before generating the code. Please fix the following issues:\n\n${testFileAnalysisResult}\n\n`;
+									const body = `The following best practices conflicts were detected in the test file: ${testFileAnalysisResult}`;
 									await github.postComment(context, body);
 								}
 							}

--- a/src/prompt/markdown/analyze_test_file.md
+++ b/src/prompt/markdown/analyze_test_file.md
@@ -13,10 +13,12 @@ Follow this structure:
 
 ```xml
 <test_file_analysis_result>
-## [Section Name]
+<details>
+<summary>[Section Name]</summary>
 ### Conflicts
 1. [Best Practice]
 - [Issue Description]
 - [Relevant test file portion]
+</details>
 </test_file_analysis_result>
 ```


### PR DESCRIPTION
Updated LLM reply format for analyze-test prompt:

- Enclosed functional requirements in `<details>` tags
- Enclosed test conflicts in `<details>` tags
- Updated wording to reflect that bad practices no longer block code generation

Reasons:

- Reducing visual clutter in Workers generation PRs (Even without these comments, it's getting hard to read through)
- Allowing focus on **test best practices**, since the functional requirements for some workers are collectively agreed upon

Concern: I am not sure if it's ok to include html tags inside xml, since they look identical. Tried to research on this, but found mixed opinions. If this is a problem, I can keep the old prompt and manually reformat response.