### PR TITLE
Docs: add Cloudflare's Browser Rendering to docs

### DIFF
--- a/src/prompt/markdown/documentation.md
+++ b/src/prompt/markdown/documentation.md
@@ -453,9 +453,8 @@ export default {
 ```
 
 ### Cloudflare Browser Rendering
-Cloudflare's Browser Rendering API allows developers to perform browser-like tasks in a cloud. It uses a fork of the popular Puppeteer library.
+Cloudflare's Browser Rendering API allows to perform browser-like tasks in a Worker. It uses a fork of the popular Puppeteer library.
 
-Example usage:
 ```typescript
 import puppeteer from "@cloudflare/puppeteer";
 


### PR DESCRIPTION
A few sentences defining Browser Rendering, clarifying that a fork of Puppeteer is used instead of the original package, and including a code example to help with proper import and browser startup