### PR TITLE
Disable Drizzle logger by default

### DIFF
--- a/src/prompt/markdown/documentation.md
+++ b/src/prompt/markdown/documentation.md
@@ -492,7 +492,7 @@ export default {
   ): Promise<Response> {
     const client = new Client({ connectionString: env.HYPERDRIVE.connectionString });
     await client.connect();
-    const db = drizzle(client, { schema: { users }, logger: true } );
+    const db = drizzle(client, { schema: { users }, logger: false } );
     const result = await db.select().from(...);
     // Clean up the client, ensuring we don't kill the worker before that is completed.
     ctx.waitUntil(client.end());


### PR DESCRIPTION
Disable Drizzle logger by default, but leave so that it can be easily enabled.

Ref https://github.com/1712n/dni-code-generation-research/pull/70