### PR TITLE
Docs: Drizzle filters code example

### DIFF
--- a/src/prompt/markdown/documentation.md
+++ b/src/prompt/markdown/documentation.md
@@ -506,8 +506,11 @@ Drizzle provides various filter and conditional operators to handle database que
 
 ```js
 import { eq, gt, gte, lt, lte, exists, isNull, inArray, between, notBetween, like, ilike, notIlike, not, and, or } from 'drizzle-orm';
+import { users } from './schema';
 
-db.select()
+const db = drizzle(...);
+
+await db.select()
 	.from(users)
 	.where(
 		and(


### PR DESCRIPTION
Replaced textual description of filters with one big code example that uses most of them, because wall-e still used some wrong