### PR TITLE
Docs: add batch examples

### DIFF
--- a/src/prompt/markdown/documentation.md
+++ b/src/prompt/markdown/documentation.md
@@ -568,7 +568,7 @@ const insertedUsers = await db
   });
 ```
 
-#### Batch Update with different values for each row
+##### Batch Update with different values for each row
 
 To implement update many with different values for each row within 1 request you can use sql operator with case statement and .update().set() methods like this:
 


### PR DESCRIPTION
As discussed on the recent call, I first asked LLMs if existing documentation favors one-by-one db operations against batching and how to fix it. It proposed some changes, but I didn't think they were enough, so I went with adding separate sections for batch operations. Added 3 examples: batch select, batch insert, batch insert with returning values.

@unicoder88 let me know if there are any type of batch operation that wall-e failed to generate for you that this PR doesn't cover