### PR TITLE
fix: generated code extraction

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import {
 	isValidModelForProvider,
 	isValidProvider,
 } from './providers';
-import { formatDebugInfo, getElapsedSeconds, ensurePath, parseCommandArgs, extractCodeBlockContent, extractXMLContent } from './utils';
+import { formatDebugInfo, getElapsedSeconds, ensurePath, parseCommandArgs, extractXMLContent, extractGeneratedCode } from './utils';
 import * as prettier from 'prettier/standalone';
 import * as prettierPluginEstree from 'prettier/plugins/estree';
 import * as parserTypeScript from 'prettier/parser-typescript';
@@ -72,8 +72,7 @@ async function commitGeneratedCode(params: CommitGeneratedCodeParams) {
 		relevantDocumentation,
 	} = params;
 
-	const extractedCode = extractCodeBlockContent(generatedCode);
-	const formattedCode = await prettier.format(extractedCode, {
+	const formattedCode = await prettier.format(generatedCode, {
 		parser: 'typescript',
 		plugins: [prettierPluginEstree, parserTypeScript],
 	});
@@ -277,7 +276,7 @@ export default {
 								},
 								fallback,
 							).then(async ({ provider, model: fallbackModel, text }) => {
-								const { generated_code: generatedCode } = extractXMLContent(text);
+								const generatedCode = extractGeneratedCode(text);
 								if (!generatedCode) {
 									const elapsedTime = getElapsedSeconds(message.timestamp);
 									const debugInfo = formatDebugInfo({
@@ -400,7 +399,7 @@ export default {
 								},
 								fallback,
 							).then(async ({ provider, model: fallbackModel, text }) => {
-								const { generated_code: generatedCode } = extractXMLContent(text);
+								const generatedCode = extractGeneratedCode(text);
 								if (!generatedCode) {
 									const elapsedTime = getElapsedSeconds(message.timestamp);
 									const debugInfo = formatDebugInfo({

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -105,3 +105,16 @@ export function extractCodeBlockContent(text: string): string {
 		.replace(incompleteOpeningPattern, '')
 		.replace(incompleteClosingPattern, '');
 }
+
+export function extractGeneratedCode(text: string): string {
+	// Try to extract generated code from XML content
+	const { generated_code: generatedCode } = extractXMLContent(text);
+
+	// If no generated code is found, try to extract code block content
+	if (!generatedCode) {
+		return extractCodeBlockContent(text);
+	}
+
+	// Extract code block content from the generated code, if present
+	return extractCodeBlockContent(generatedCode);
+}


### PR DESCRIPTION
LLMs sometimes add both the `<generated_code>` XML tag and a `markdown`-wrapped code block, while other times they use only one. This fix handles all cases properly.