### PR TITLE
bug: gemini-1.5-pro-002

### DIFF
--- a/src/providers/googleai.ts
+++ b/src/providers/googleai.ts
@@ -82,9 +82,8 @@ type GoogleGeminiParsedResponse = {
 	meta?: any[];
 };
 
-export function googleGeminiParsedResponse(response: GoogleGeminiResponse[]): GoogleGeminiParsedResponse {
+export function googleGeminiParsedResponse(response: GoogleGeminiResponse[], requestedModel: ModelName): GoogleGeminiParsedResponse {
 	let text = '';
-	let model;
 	let meta = [];
 
 	for (const res of response) {
@@ -93,7 +92,7 @@ export function googleGeminiParsedResponse(response: GoogleGeminiResponse[]): Go
 				for (const candidate of res.candidates) {
 					if (candidate.content && candidate.content.parts) {
 						for (const part of candidate.content.parts) {
-							text += part.text; // Accumulate the text from each part
+							text += part.text;
 						}
 
 						if (candidate.groundingMetadata) {
@@ -107,19 +106,13 @@ export function googleGeminiParsedResponse(response: GoogleGeminiResponse[]): Go
 		} catch (error) {
 			console.error('Error processing response from Gemini model:', error);
 			console.error('Gemini response:', JSON.stringify(res, null, 2));
-			throw error; // Re-throw the error after logging
+			throw error;
 		}
-	}
-
-	try {
-		model = response[0].modelVersion;
-	} catch (error) {
-		console.error('Error extracting model version from Gemini response:', error);
 	}
 
 	return {
 		text,
-		model: model as ModelName,
+		model: requestedModel,
 		meta
 	};
 }

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -211,7 +211,10 @@ function getModelProviderFromEvents(events: any[]): ModelProvider {
 	return ModelProvider.Unknown;
 }
 
-export async function handleStreamResponse(reader: ReadableStreamDefaultReader<any>): Promise<SendPromptResponse> {
+export async function handleStreamResponse(
+	reader: ReadableStreamDefaultReader<any>,
+	params: ProviderRequestParams
+): Promise<SendPromptResponse> {
 	const events = await parseStreamedEvents(reader);
 	console.log('All events:', JSON.stringify(events, null, 2));
 
@@ -237,7 +240,7 @@ export async function handleStreamResponse(reader: ReadableStreamDefaultReader<a
 				};
 
 			case ModelProvider.GoogleAi:
-				const response = googleGeminiParsedResponse(events);
+				const response = googleGeminiParsedResponse(events, params.model);
 				return {
 					...response,
 					provider,


### PR DESCRIPTION
probable fix for https://github.com/1712n/dni-code-generation-research/pull/85#issuecomment-2559311426
probable because i don't see any errors in wall-e logs and can't trace what goes wrong

tldr: when specifying `gemini-1.5-pro-002`, wall-e uses `claude` instead; probably related to how `model` is parsed from the Gemini API response, so it fallbacks to claude