### PR TITLE
fix: google search retrieval config

### DIFF
--- a/src/providers/googleai.ts
+++ b/src/providers/googleai.ts
@@ -45,7 +45,7 @@ export function googleAIStudioRequest({ model, apiKey, prompts }: ProviderReques
 			googleSearchRetrieval: {
 				dynamicRetrievalConfig: {
 					mode: DynamicRetrievalMode.DYNAMIC,
-					dynamicThreshold: 0.3,
+					dynamicThreshold: 0,
 				},
 			},
 		});


### PR DESCRIPTION
Setting the `dynamicRetrievalConfig` object no longer makes the request fail