### PR TITLE
Fix: change default provider in readme 

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The prompt sent to the LLM consists of 2 sections: instructions and a spec file.
 
 #### Instructions
 
-The [instructions section](src/prompt/markdown) of the prompt explains the task and the general environment. It's relatively static and shouldn't change too often.
+The [instructions section](src/prompt/markdown/generate_worker.md) of the prompt explains the task and the general environment. It's relatively static and shouldn't change too often.
 
 #### `test/index.spec.ts`
 


### PR DESCRIPTION
- Fixed readme to have googleai as default provider
- "instructions section"  used to go to non-existing file, now links to generate_worker prompt