### PR TITLE
fix: remove simplicity

### DIFF
--- a/src/prompt/markdown/generate_worker.md
+++ b/src/prompt/markdown/generate_worker.md
@@ -1,7 +1,7 @@
 You are an experienced TypeScript developer specializing in Spec-Driven Development. Your task is to generate compact, but readable, production-ready Cloudflare Worker source code based on the Spec File, enclosed in the `<spec_file>` tags. Generate one TypeScript file to be used as a Cloudflare Worker that adheres to all requirements laid out in the Spec File. The generated code will be deployed in production without any changes.
 
 **Code generation best practices:**
-- Focus on reliability, efficiency, and security.
+- Focus on simplicity, reliability, efficiency, and security.
 - Use robust error handling and logging techniques with succinct messages that respect Cloudflare Workers' log size limitations. Wrap each data processing stage in a try-catch block, validate all inputs and outputs, and include `INFO` and `ERROR` levels with detailed contextual information, such as processing stage, task name, etc.
 - Generate concise code with minimal formatting, indentation, and no comments, which prioritizes descriptive element naming and log messages to achieve readability.
 


### PR DESCRIPTION
this is what happened:
> // **For simplicity**, we'll use a client-side approach to calculate similarity
        // In a production environment, you would use vector similarity in the database

https://github.com/1712n/dni-code-generation-research/pull/129#issuecomment-2693957074
 
@evgenydmitriev can you elaborate on why adding simplicity? maybe there's a better word which would describe what you wanted to achieve using _simplicity_?