### PR TITLE
fix: max_tokens limits

### DIFF
--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -47,9 +47,24 @@ export function anthropicRequest({ model, prompts, apiKey, stream, temperature }
 		actualModel = ModelName.Claude_4_Sonnet;
 	}
 
+	let max_tokens: number;
+	
+	// Explicitly configure max_tokens for each Claude 4 model
+	if (model === ModelName.Claude_4_Opus_thinking) {
+		max_tokens = 32_000;
+	} else if (model === ModelName.Claude_4_Sonnet_thinking) {
+		max_tokens = 64_000;
+	} else if (model === ModelName.Claude_4_Opus) {
+		max_tokens = 32_000;
+	} else if (model === ModelName.Claude_4_Sonnet) {
+		max_tokens = 64_000;
+	} else {
+		throw new Error(`Unsupported model: ${model}`);
+	}
+
 	const query: AnthropicQuery = {
 		model: actualModel,
-		max_tokens: 8_192,
+		max_tokens,
 		stream,
 		system,
 		messages: [
@@ -61,26 +76,21 @@ export function anthropicRequest({ model, prompts, apiKey, stream, temperature }
 		temperature,
 	};
 
+	// Configure thinking mode for thinking models
 	if (model === ModelName.Claude_4_Sonnet_thinking || model === ModelName.Claude_4_Opus_thinking) {
-    if (model === ModelName.Claude_4_Opus_thinking) {
-        query.max_tokens = 32_000; 
-        query.thinking = {
-            type: 'enabled',
-            budget_tokens: 20_000,  
-        };
-    } else {
-        query.max_tokens = 64_000;
-        query.thinking = {
-            type: 'enabled',
-            budget_tokens: 32_000, 
-        };
-    }
-    query.temperature = 1;
-} else if (model === ModelName.Claude_4_Opus) {
-    query.max_tokens = 32_000;
-} else if (model === ModelName.Claude_4_Sonnet) {
-    query.max_tokens = 64_000;
-}
+		if (model === ModelName.Claude_4_Opus_thinking) {
+			query.thinking = {
+				type: 'enabled',
+				budget_tokens: 20_000,  
+			};
+		} else {
+			query.thinking = {
+				type: 'enabled',
+				budget_tokens: 32_000, 
+			};
+		}
+		query.temperature = 1;
+	}
 
 	return {
 		provider: 'anthropic',


### PR DESCRIPTION
### Issue
API requests were failing with: `max_tokens: 128000 > 32000, which is the maximum allowed number of output tokens for claude-opus-4-20250514`, https://github.com/1712n/wall-e/pull/241#issuecomment-2906965865

see [models limits](https://docs.anthropic.com/en/docs/about-claude/models/overview#model-comparison-table) for input/output, we don't have 128k output anymore.

> **Claude may not use the entire budget allocated, especially at ranges above 32k.**

> `budget_tokens` must be set to a value less than `max_tokens`. 

### Changes
- Set correct max_tokens limits: 32k for Opus, 64k for Sonnet
- Opus thinking: 20k thinking budget, 12k output
- Sonnet thinking: 32k thinking budget, 32k output